### PR TITLE
Fix GCC 16 ICE caused by constexpr Quad temporary construction

### DIFF
--- a/src/opengl/experimental/test/TestBatchRenderingTexture2D.cpp
+++ b/src/opengl/experimental/test/TestBatchRenderingTexture2D.cpp
@@ -37,8 +37,7 @@ test::TestBatchRenderingTexture2D::TestBatchRenderingTexture2D()
                    glm::vec3{ 4.F, 0.F, 0.F } + offset, colors[2], 3);
 
      m_vertex_buffer           = glengine::VertexBuffer{ vertices };
-     constexpr auto quad_size  = std::size(glengine::Quad{});
-     const auto     quad_count = std::size(vertices) / quad_size;
+     const auto     quad_count = std::size(vertices) / glengine::VerticesPerQuad;
      m_index_buffer
        = glengine::IndexBuffer{ glengine::QuadIndices(quad_count) };
 

--- a/src/opengl/glengine/glengine/Vertex.cpp
+++ b/src/opengl/glengine/glengine/Vertex.cpp
@@ -52,14 +52,13 @@ std::vector<std::uint32_t> QuadIndices(std::size_t count)
 {
      std::vector<std::uint32_t> indices{};
      indices.reserve(std::size(QuadIndicesInit) * count);
-     static constexpr auto quad_size = std::size(Quad{});
      for (std::size_t i{}; i != count; ++i)
      {
           std::ranges::transform(
             QuadIndicesInit,
             std::back_inserter(indices),
             [&i](std::uint32_t index)
-            { return static_cast<std::uint32_t>(index + i * quad_size); });
+            { return static_cast<std::uint32_t>(index + i * VerticesPerQuad); });
      }
      return indices;
 }

--- a/src/opengl/glengine/glengine/Vertex.hpp
+++ b/src/opengl/glengine/glengine/Vertex.hpp
@@ -39,6 +39,8 @@ static_assert(
   && std::default_initializable<Vertex>);
 
 using Quad = std::array<Vertex, 4U>;
+inline constexpr std::size_t VerticesPerQuad =
+  std::tuple_size_v<Quad>;
 static constexpr auto QuadIndicesInit
   = std::array<std::uint32_t, 6U>{ 0, 1, 2, 2, 3, 0 };
 
@@ -51,7 +53,6 @@ constexpr inline std::array<
 {
      using std::ranges::size;
      std::array<std::uint32_t, count * size(QuadIndicesInit)> indices{};
-     constexpr auto quad_size = size(Quad{});
      for (std::size_t i{}; i != count; ++i)
      {
           using std::ranges::range_difference_t;
@@ -67,7 +68,7 @@ constexpr inline std::array<
             QuadIndicesInit,
             f,
             [&](std::uint32_t index)
-            { return static_cast<std::uint32_t>(index + i * quad_size); });
+            { return static_cast<std::uint32_t>(index + i * VerticesPerQuad); });
      }
      return indices;
 }
@@ -79,15 +80,14 @@ Quad CreateQuad(
   const float     tiling_factor = 1.F,
   const std::array<
     glm::vec2,
-    4U> uv
-  = { glm::vec2{ 0.F,
-                 0.F },
-      glm::vec2{ 1.F,
-                 0.F },
-      glm::vec2{ 1.F,
-                 1.F },
-      glm::vec2{ 0.F,
-                 1.F } },
+    4U>               uv      = { glm::vec2{ 0.F,
+                                             0.F },
+                                  glm::vec2{ 1.F,
+                                             0.F },
+                                  glm::vec2{ 1.F,
+                                             1.F },
+                                  glm::vec2{ 0.F,
+                                             1.F } },
   const glm::vec2     size    = { 1.F,
                                   1.F },
   const int           id      = -1,

--- a/src/opengl/glengine/glengine/VertexBufferDynamic.hpp
+++ b/src/opengl/glengine/glengine/VertexBufferDynamic.hpp
@@ -52,7 +52,7 @@ class VertexBufferDynamic
               * sizeof(std::ranges::range_value_t<T>)),
             std::ranges::data(vertices));
           return glengine::IndexBufferDynamicSize(
-            (std::ranges::size(vertices) / std::size(Quad{}) * IndicesPerQuad));
+            (std::ranges::size(vertices) / VerticesPerQuad * IndicesPerQuad));
      }
 };
 static_assert(Bindable<VertexBufferDynamic>);


### PR DESCRIPTION
Fix GCC 16 ICE from constexpr Quad temporary construction

Replace `std::size(Quad{})` usages with shared
`VerticesPerQuad` constexpr based on `std::tuple_size_v<Quad>`.

This avoids a GCC 16 internal compiler error triggered during
template substitution while preserving existing behavior.

Also updates related quad index/count calculations to use the
shared constant consistently.