### PR TITLE
Remove duplicate fmt formatter specialization and update upstream.

### DIFF
--- a/src/opengl/main/formatters.hpp
+++ b/src/opengl/main/formatters.hpp
@@ -119,42 +119,6 @@ struct fmt::formatter<ff_8::draw_bitT> : fmt::formatter<std::string_view>
 };
 
 template<>
-struct fmt::formatter<open_viii::graphics::background::BlendModeT>
-  : fmt::formatter<std::string_view>
-{
-     // parse is inherited from formatter<string_view>.
-     template<typename FormatContext>
-     constexpr auto format(
-       open_viii::graphics::background::BlendModeT blend_mode_t,
-       FormatContext                              &ctx) const
-     {
-          using namespace open_viii::graphics::background;
-          using namespace std::string_view_literals;
-          std::string_view name = {};
-          switch (blend_mode_t)
-          {
-               case BlendModeT::add:
-                    name = "add"sv;
-                    break;
-               case BlendModeT::half_add:
-                    name = "half add"sv;
-                    break;
-               case BlendModeT::none:
-                    name = "none"sv;
-                    break;
-               case BlendModeT::quarter_add:
-                    name = "quarter add"sv;
-                    break;
-               case BlendModeT::subtract:
-                    name = "subtract"sv;
-                    break;
-          }
-          return fmt::formatter<std::string_view>::format(name, ctx);
-     }
-};
-
-
-template<>
 struct fmt::formatter<draw_mode> : fmt::formatter<std::string_view>
 {
      // parse is inherited from formatter<string_view>.
@@ -265,23 +229,6 @@ struct fmt::formatter<open_viii::LangT> : fmt::formatter<std::string_view>
      }
 };
 
-template<open_viii::Number numT>
-struct fmt::formatter<open_viii::graphics::Point<numT>> : fmt::formatter<numT>
-{
-     // parse is inherited from formatter<std::underlying_type_t<tile_sizes>>.
-     template<typename FormatContext>
-     constexpr auto format(
-       open_viii::graphics::Point<numT> point,
-       FormatContext                   &ctx) const
-     {
-          fmt::format_to(ctx.out(), "{}", '(');
-          fmt::formatter<numT>::format(point.x(), ctx);
-          fmt::format_to(ctx.out(), "{}", ", ");
-          fmt::formatter<numT>::format(point.y(), ctx);
-          return fmt::format_to(ctx.out(), "{}", ')');
-     }
-};
-
 template<>
 struct fmt::formatter<fme::BackgroundSettings>
 {
@@ -349,35 +296,6 @@ struct fmt::formatter<open_viii::graphics::Rectangle<numT>>
             ctx);
      }
 };
-
-template<>
-struct fmt::formatter<open_viii::graphics::BPPT> : fmt::formatter<std::uint32_t>
-{
-     // parse is inherited from formatter<string_view>.
-     template<typename FormatContext>
-     constexpr auto format(
-       open_viii::graphics::BPPT bppt,
-       FormatContext            &ctx) const
-     {
-          using namespace open_viii::graphics;
-          using namespace std::string_view_literals;
-
-          if (bppt.bpp8())
-          {
-               return fmt::formatter<std::uint32_t>::format(BPPT::BPP8, ctx);
-          }
-          if (bppt.bpp16())
-          {
-               return fmt::formatter<std::uint32_t>::format(BPPT::BPP16, ctx);
-          }
-          if (bppt.bpp24())
-          {
-               return fmt::formatter<std::uint32_t>::format(BPPT::BPP24, ctx);
-          }
-          return fmt::formatter<std::uint32_t>::format(BPPT::BPP4, ctx);
-     }
-};
-
 
 template<open_viii::graphics::background::is_tile tileT>
 struct fmt::formatter<tileT> : fmt::formatter<std::string>

--- a/src/opengl/main/gui/import.cpp
+++ b/src/opengl/main/gui/import.cpp
@@ -202,8 +202,9 @@ open_viii::graphics::background::Map::variant_tile &
      const auto pop_item_width = glengine::ScopeGuard(&ImGui::PopItemWidth);
 
 
-     if (ImGui::BeginCombo(
-           "##Select Existing Tile", "", ImGuiComboFlags_HeightLarge))
+     if (
+       ImGui::BeginCombo(
+         "##Select Existing Tile", "", ImGuiComboFlags_HeightLarge))
      {
           static constexpr int columnWidth = 100;// Adjust as needed
           const auto           num_columns = std::max(
@@ -228,43 +229,44 @@ open_viii::graphics::background::Map::variant_tile &
                       bool is_selected
                         = (selections->get<ConfigKey::ImportSelectedTile>() == tile_id);// You can store your selection however you
                                                                                         // want, outside or inside your objects
-                      if (std::ranges::any_of(
-                            std::array{
-                              [&]() -> bool
-                              {
-                                   bool const selected
-                                     = ImGui::Selectable("", is_selected);
-                                   tool_tip(
-                                     [&]()
-                                     {
-                                          format_imgui_text("{}", tile_id);
-                                          const tile_button_options options
-                                            = { .size = { tooltips_size,
-                                                          tooltips_size } };
-                                          (void)create_tile_button(
-                                            map_sprite, tile, options);
-                                          // map_sprite->enable_square(tile);
-                                          was_hovered = true;
-                                     });
-                                   return selected;
-                              }(),
-                              []() -> bool
-                              {
-                                   ImGui::SameLine();
-                                   return false;
-                              }(),
-                              create_tile_button(map_sprite, tile),
-                              []() -> bool
-                              {
-                                   ImGui::SameLine();
-                                   return false;
-                              }(),
-                              [&tile_id]() -> bool
-                              {
-                                   format_imgui_text("{}", tile_id);
-                                   return false;
-                              }() },
-                            std::identity{}))
+                      if (
+                        std::ranges::any_of(
+                          std::array{
+                            [&]() -> bool
+                            {
+                                 bool const selected
+                                   = ImGui::Selectable("", is_selected);
+                                 tool_tip(
+                                   [&]()
+                                   {
+                                        format_imgui_text("{}", tile_id);
+                                        const tile_button_options options
+                                          = { .size = { tooltips_size,
+                                                        tooltips_size } };
+                                        (void)create_tile_button(
+                                          map_sprite, tile, options);
+                                        // map_sprite->enable_square(tile);
+                                        was_hovered = true;
+                                   });
+                                 return selected;
+                            }(),
+                            []() -> bool
+                            {
+                                 ImGui::SameLine();
+                                 return false;
+                            }(),
+                            create_tile_button(map_sprite, tile),
+                            []() -> bool
+                            {
+                                 ImGui::SameLine();
+                                 return false;
+                            }(),
+                            [&tile_id]() -> bool
+                            {
+                                 format_imgui_text("{}", tile_id);
+                                 return false;
+                            }() },
+                          std::identity{}))
                       {
                            selections->get<ConfigKey::ImportSelectedTile>()
                              = tile_id;
@@ -437,9 +439,10 @@ bool import::browse_for_image_display_preview() const
             glengine::ConvertGliDtoImTextureId<ImTextureID>(
               m_loaded_image_texture.id()),
             ImVec2(width, height));
-          if (ImGui::Checkbox(
-                gui_labels::draw_grid.data(),
-                &selections->get<ConfigKey::ImportImageGrid>()))
+          if (
+            ImGui::Checkbox(
+              gui_labels::draw_grid.data(),
+              &selections->get<ConfigKey::ImportImageGrid>()))
           {
                selections->update<ConfigKey::ImportImageGrid>();
           }
@@ -512,7 +515,7 @@ bool import::combo_tile_size() const
                      tile_sizes::x_16_size };
      static const auto strings = values | std::views::transform(AsString{})
                                  | std::ranges::to<std::vector>();
-     const auto gcc = GenericCombo(
+     const auto        gcc     = GenericCombo(
        gui_labels::tile_size,
        values,
        strings,
@@ -570,8 +573,8 @@ void import::generate_map_for_imported_image(
                       [&](auto tile)
                         -> open_viii::graphics::background::Map::variant_tile
                       {
-                           if constexpr (is_tile<
-                                           std::remove_cvref_t<decltype(tile)>>)
+                           if constexpr (
+                             is_tile<std::remove_cvref_t<decltype(tile)>>)
                            {
                                 if (x_tile == tiles_wide)
                                 {
@@ -840,7 +843,7 @@ void import::reset_imported_image() const
           return;
      }
      map_sprite->update_render_texture(nullptr, {}, tile_sizes::default_size);
-     m_import_image_map                                = {};
+     m_import_image_map.reset();
      m_loaded_image_texture                            = {};
      // m_loaded_image_cpu                = {};
      m_import_image_path                               = {};
@@ -885,15 +888,17 @@ void import::find_selected_tile_for_import(
             std::visit(
               [&](const auto &tile)
               {
-                   if (std::cmp_less(
-                         selections->get<ConfigKey::ImportSelectedTile>(),
-                         tiles.size()))
+                   if (
+                     std::cmp_less(
+                       selections->get<ConfigKey::ImportSelectedTile>(),
+                       tiles.size()))
                    {
                         const auto &tmp_tile = tiles[static_cast<size_t>(
                           selections->get<ConfigKey::ImportSelectedTile>())];
-                        if constexpr (std::is_same_v<
-                                        std::decay_t<decltype(tile)>,
-                                        std::decay_t<decltype(tmp_tile)>>)
+                        if constexpr (
+                          std::is_same_v<
+                            std::decay_t<decltype(tile)>,
+                            std::decay_t<decltype(tmp_tile)>>)
                         {
                              if (tile != tmp_tile)
                              {
@@ -982,9 +987,10 @@ bool import::checkbox_render_imported_image() const
                return false;
           }
 
-          if (ImGui::Checkbox(
-                gui_labels::render_imported_image.data(),
-                &selections->get<ConfigKey::RenderImportedImage>()))
+          if (
+            ImGui::Checkbox(
+              gui_labels::render_imported_image.data(),
+              &selections->get<ConfigKey::RenderImportedImage>()))
           {
                selections->update<ConfigKey::RenderImportedImage>();
                // Pass texture and map and tile_size

--- a/src/opengl/main/mim_sprite.cpp
+++ b/src/opengl/main/mim_sprite.cpp
@@ -128,9 +128,7 @@ void mim_sprite::save(const std::filesystem::path &dest_path) const
             m_colors,
             width(),
             height(),
-            dest_path.string(),
-            dest_path.stem().string(),
-            "");
+            { .filename = dest_path.string(), .prefix = "" });
      }
 }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "field-map-editor",
   "version": "1.0.5",
-  "builtin-baseline": "4334d8b4c8916018600212ab4dd4bbdc343065d1",
+  "builtin-baseline": "4f1406d8f7923c3fff34738b6177f72b143ad5b6",
   "dependencies": [
     "lz4",
     "spdlog",
+    "fmt",
     "glfw3",
     "glew",
     "glm",
@@ -34,6 +35,11 @@
     {
       "name": "spdlog",
       "version": "1.15.3",
+      "port-version": 0
+    },
+    {
+      "name": "fmt",
+      "version": "12.0.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
Delete local formatter specializations for BlendModeT, BPPT, and Point now provided or instantiated earlier by upstream OpenVIII_CPP_WIP headers.

Fixes fmt v11 redefinition and specialization-after-instantiation build errors.

Refactors formatting and layout in `import.cpp` for improved readability and consistency.

Also replaces implicit optional clearing:

```cpp
m_import_image_map = {};
```

with the more explicit:

```cpp
m_import_image_map.reset();
```

## Changes

- Reformat multiline `ImGui::*` conditionals
- Normalize wrapping of `if constexpr` and comparison expressions
- Align local variable spacing
- Replace optional clearing assignment with `.reset()`
- General readability cleanup in import GUI code

## Notes

No functional changes intended besides the explicit optional reset behavior.

Replace deprecated positional Png::save arguments with
SaveSettings initialization to match upstream OpenVIII_CPP_WIP
API changes.

build: add fmt dependency and update vcpkg baseline

- add fmt to vcpkg dependencies
- pin fmt version to 12.0.0
- update vcpkg builtin baseline